### PR TITLE
Update README with database features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ It relies on the Tkinter GUI toolkit and the module set published by
 ## Requirements
 
 - **Python**: developed with Python **3.13**.
-- **Libraries**: `pyyaml` is required to load configuration. The game also uses
-  `Pillow` for image handling.
+ - **Libraries**: `pyyaml` is required to load configuration. The game also uses
+  `Pillow` for image handling. To save match history in a database, install
+  `mysql-connector-python`.
 
 Install the dependencies with `pip`:
 
 ```bash
-pip install pyyaml pillow
+pip install pyyaml pillow mysql-connector-python
 ```
 
 ## Running the Game
@@ -41,11 +42,19 @@ WHITE_STONE_IMAGE_PATH: "images/stone_white.png"
 
 PNG format is expected for all images.
 
-## Future Plans
+## Match History
 
-A database interface (`History.DBControler`) is under development to save and
-restore match histories. This functionality is not yet available and the
-application currently does not connect to any external database.
+Matches can now be recorded in a MySQL database. From the history screen you
+can replay any saved game, resume from the middle of a match or watch it play
+out to the end.
+
+## Database Setup
+
+To enable the database features:
+
+1. Install the `mysql-connector-python` library.
+2. Create a MySQL database where match history will be stored.
+3. Enter your connection details in `database_info.yaml`.
 
 ## Credits
 
@@ -63,12 +72,14 @@ Tkinterを使ったGUIと、[magu1436](https://github.com/magu1436/TkinterBoardG
 ## 必要要件
 
 - **Python**: このプログラムは **Python 3.13** で開発されました。
-- **ライブラリ**: 設定読み込みに `pyyaml` を使用します。また画像表示に `Pillow` が必要です。
+- **ライブラリ**: 設定読み込みに `pyyaml` を使用します。また画像表示に `Pillow`
+  が必要です。対戦履歴をデータベースに保存する場合は
+  `mysql-connector-python` もインストールしてください。
 
 以下のコマンドで依存パッケージをインストールしてください。
 
 ```bash
-pip install pyyaml pillow
+pip install pyyaml pillow mysql-connector-python
 ```
 
 ## ゲームの起動
@@ -94,9 +105,17 @@ WHITE_STONE_IMAGE_PATH: "images/stone_white.png"
 
 すべての画像は PNG 形式である必要があります。
 
-## 今後の予定
+## 対戦履歴
 
-対戦履歴を保存・復元できるデータベースインターフェース (`History.DBControler`) を開発中です。現在はまだ利用できず、外部データベースへの接続もしていません。
+対局結果を MySQL データベースに保存できます。履歴一覧画面から記録した対局を再生し、途中から再開したり、最後まで進行を確認することが可能です。
+
+## データベース準備
+
+以下を行うことでデータベース機能を利用できます。
+
+1. `mysql-connector-python` ライブラリを導入する。
+2. 履歴を保存するための MySQL データベースを作成する。
+3. `database_info.yaml` に接続情報を記入する。
 
 ## クレジット
 


### PR DESCRIPTION
## Summary
- document new MySQL-based history feature
- add instructions for mysql-connector, DB creation, and configuration

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b343aa31883308bdbdaec7983a3c1